### PR TITLE
Update go-github to v45

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 # Task installation in Github Actions 
 bin/task
+
+.idea

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ package main
 import (
 	"github.com/telia-oss/githubapp"
 
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v45/github"
 )
 
 func main() {

--- a/app.go
+++ b/app.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v45/github"
 )
 
 // AppsJWTAPI is the interface that is satisfied by the Apps client when authenticated with a JWT.

--- a/app_e2e_test.go
+++ b/app_e2e_test.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v45/github"
 	"github.com/telia-oss/githubapp"
 )
 

--- a/app_test.go
+++ b/app_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/telia-oss/githubapp"
 	"github.com/telia-oss/githubapp/fakes"
 
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v45/github"
 )
 
 func isEqual(t *testing.T, expected, got interface{}) {
@@ -34,34 +34,45 @@ func TestGithubApp(t *testing.T) {
 		expiresAt     = time.Now().Add(1 * time.Hour)
 	)
 
-	client.ListInstallationsReturns([]*github.Installation{{
-		ID: github.Int64(23),
-		Account: &github.User{
-			Login: github.String("owner"),
-		},
-	}}, &github.Response{}, nil)
+	client.ListInstallationsReturns(
+		[]*github.Installation{
+			{
+				ID: github.Int64(23),
+				Account: &github.User{
+					Login: github.String("owner"),
+				},
+			},
+		}, &github.Response{}, nil,
+	)
 
-	client.CreateInstallationTokenReturns(&github.InstallationToken{
-		Token:        github.String("token"),
-		ExpiresAt:    &expiresAt,
-		Permissions:  nil,
-		Repositories: nil,
-	}, nil, nil)
+	client.CreateInstallationTokenReturns(
+		&github.InstallationToken{
+			Token:        github.String("token"),
+			ExpiresAt:    &expiresAt,
+			Permissions:  nil,
+			Repositories: nil,
+		}, nil, nil,
+	)
 
-	tokenClient.ListReposReturns(&github.ListRepositories{
-		TotalCount: github.Int(1),
-		Repositories: []*github.Repository{{
-			ID:   github.Int64(23),
-			Name: github.String("repository"),
-		}},
-	}, &github.Response{}, nil)
+	tokenClient.ListReposReturns(
+		&github.ListRepositories{
+			TotalCount: github.Int(1),
+			Repositories: []*github.Repository{
+				{
+					ID:   github.Int64(23),
+					Name: github.String("repository"),
+				},
+			},
+		}, &github.Response{}, nil,
+	)
 
 	token, err := gh.CreateInstallationToken(
 		"owner",
 		[]string{"repository"},
 		&githubapp.Permissions{
 			Metadata: github.String("read"),
-		})
+		},
+	)
 	noError(t, err)
 	isEqual(t, "token", token.GetToken())
 	isEqual(t, expiresAt, token.GetExpiresAt())

--- a/client.go
+++ b/client.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation"
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v45/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )

--- a/fakes/fake_jwt_api.go
+++ b/fakes/fake_jwt_api.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v45/github"
 	"github.com/telia-oss/githubapp"
 )
 

--- a/fakes/fake_token_api.go
+++ b/fakes/fake_token_api.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v45/github"
 	"github.com/telia-oss/githubapp"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/bradleyfalzon/ghinstallation v1.1.1
-	github.com/google/go-github/v41 v41.0.0
+	github.com/google/go-github/v45 v45.2.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/shurcooL/githubv4 v0.0.0-20200414012201-bbc966b061dd
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,12 +89,12 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
 github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
-github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
-github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
+github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
+github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
To be able to use Dependabot in projects using the `telia-oss/githubapp` package, we need to update go-github to use `v45` instead of `v41`